### PR TITLE
Coverage pipeline update

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -71,7 +71,7 @@ user@ubuntu$ export OPENAI_PROXY_BASE=https://openai.proxy.com/v1
 
 > If you need to run CNTG on your local models, you should use [vllm](https://github.com/vllm-project/vllm) or other inference engines to deploy your LLM service first.
 
-### 4. Generate Fuzz drivers
+### 4. Generate seeds
 
 CNTG generates API sequences. There are several options that can be tuned in the configuration.
 

--- a/src/bin/harness.rs
+++ b/src/bin/harness.rs
@@ -20,17 +20,17 @@ pub struct Config {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Fuse the api combination in seeds to a single executable.
-    CNTGFuse {
+    FuseSeeds {
         /// the path of seeds to fuse
         seed_dir: Option<PathBuf>,
     },
     /// Collect coverage for CNTG fused programs
-    CollectCNTG,
+    CollectCoverage,
     /// Report coverage for CNTG fused programs
-    ReportCNTG,
+    ReportCoverage,
 }
 
-fn cntg_fuse(
+fn fuse_seeds(
     project: String,
     seed_dir: &Option<PathBuf>,
 ) -> Result<()> {
@@ -52,12 +52,12 @@ fn cntg_fuse(
     Ok(())
 }
 
-fn collect_cntg(project: String) -> Result<()> {
+fn collect_coverage(project: String) -> Result<()> {
     let deopt = Deopt::new(project)?;
     let cntg_dir = deopt.get_library_cntg_dir()?;
     
     if !cntg_dir.exists() {
-        eyre::bail!("CNTG directory not found: {cntg_dir:?}. Please run 'cntg-fuse' first.");
+        eyre::bail!("CNTG directory not found: {cntg_dir:?}. Please run 'fuse-seeds' first.");
     }
     
     let executor = Executor::new(&deopt)?;
@@ -67,11 +67,11 @@ fn collect_cntg(project: String) -> Result<()> {
     Ok(())
 }
 
-fn report_cntg(project: String) -> Result<()> {
+fn report_coverage(project: String) -> Result<()> {
     let deopt = Deopt::new(project)?;
     let cntg_dir = deopt.get_library_cntg_dir()?;
     if !cntg_dir.exists() {
-        eyre::bail!("CNTG directory not found: {cntg_dir:?}. Please run 'cntg-fuse' first.");
+        eyre::bail!("CNTG directory not found: {cntg_dir:?}. Please run 'fuse-seeds' first.");
     }
 
     // 1. Collect coverage
@@ -107,24 +107,24 @@ fn main() -> ExitCode {
     prompt_fuzz::config::Config::init_test(&config.project);
     let project = config.project.clone();
     match &config.command {
-        Commands::CNTGFuse {
+        Commands::FuseSeeds {
             seed_dir,
         } => {
-            if let Err(err) = cntg_fuse(project, seed_dir) {
-                log::error!("Failed to fuse CNTG programs: {}", err);
+            if let Err(err) = fuse_seeds(project, seed_dir) {
+                log::error!("Failed to fuse seeds: {}", err);
                 return ExitCode::FAILURE;
             }
         }
-        Commands::CollectCNTG => {
-            if let Err(err) = collect_cntg(project) {
-                log::error!("Failed to collect CNTG coverage: {}", err);
+        Commands::CollectCoverage => {
+            if let Err(err) = collect_coverage(project) {
+                log::error!("Failed to collect coverage: {}", err);
                 return ExitCode::FAILURE;
             }
             return ExitCode::SUCCESS;
         }
-        Commands::ReportCNTG => {
-            if let Err(err) = report_cntg(project) {
-                log::error!("Failed to report CNTG coverage: {}", err);
+        Commands::ReportCoverage => {
+            if let Err(err) = report_coverage(project) {
+                log::error!("Failed to report coverage: {}", err);
                 return ExitCode::FAILURE;
             }
             return ExitCode::SUCCESS;

--- a/src/minimize.rs
+++ b/src/minimize.rs
@@ -39,6 +39,9 @@ pub fn minimize_by_api_pairs(deopt: &Deopt) -> Result<()> {
     // 1. Get all successful programs and the API pairs they contain.
     let mut programs_with_pairs: Vec<(PathBuf, HashSet<(String, String)>)> = Vec::new();
     for file in crate::deopt::utils::read_sort_dir(&succ_seeds_dir)? {
+        if file.is_dir() {
+            continue;
+        }
         let program = Program::load_from_path(&file)?;
         let pairs = extract_api_pairs_from_program(&program);
         if !pairs.is_empty() {

--- a/src/program/cntg.rs
+++ b/src/program/cntg.rs
@@ -1,6 +1,6 @@
 use crate::deopt::Deopt;
 use std::path::{Path, PathBuf};
-use eyre::{Context, Result};
+use eyre::{Context, Result, eyre};
 
 /// CNTGProgram represents a single executable created from multiple API combination programs.
 /// Unlike LibFuzzer, this keeps the original main() functions and fuses them into one binary.
@@ -184,20 +184,33 @@ impl CNTGProgram {
 
     pub fn compile(&self) -> Result<()> {
         let executor = crate::execution::Executor::new(&self.deopt)?;
-        for dir in std::fs::read_dir(self.deopt.get_library_cntg_dir()?)? {
-            let core_dir = dir?.path();
-            if core_dir.is_dir() {
-                log::info!("Compile to Core: {core_dir:?}");
-                let core_binary = get_core_path(&core_dir);
-                executor.compile_lib_fuzzers(
-                    &core_dir,
-                    &core_binary,
-                    crate::execution::Compile::CoverageNoFuzz,
-                )?;
-                self.deopt.copy_library_init_file(&core_dir)?;
+        std::thread::scope(|s| {
+            let mut handles = Vec::<std::thread::ScopedJoinHandle::<()>>::new();
+            for dir in std::fs::read_dir(self.deopt.get_library_cntg_dir().unwrap()).unwrap() {
+                handles.push(
+                    s.spawn(|| {
+                        let core_dir = dir.unwrap().path();
+                        if core_dir.is_dir() {
+                            log::info!("Compile to Core: {core_dir:?}");
+                            let core_binary = get_core_path(&core_dir);
+                            executor.compile_lib_fuzzers(
+                                &core_dir,
+                                &core_binary,
+                                crate::execution::Compile::CoverageNoFuzz,
+                            ).unwrap();
+                            self.deopt.copy_library_init_file(&core_dir).unwrap();
+                        }
+                    })
+                );
             }
-        }
-        Ok(())
+            for handle in handles {
+                let result = handle.join();
+                if result.is_err() {
+                    return Err(eyre!(""));
+                }
+            }
+            return Ok(());
+        })
     }
 }
 


### PR DESCRIPTION
### Summary

Improve existing pipeline for obtaining library coverage of generated API sequences

### Description

* Change names of harness subcommands to be more descriptive
    * `cntg-fuse -> fuse-seeds`
    * `collect-cntg -> collect-coverage`
    * `report-cntg -> report-coverage`
* Add full pipeline `harness` subcommand `all`
* Add batched fusing for `fuse-seeds` to improve performance.
    * Multiple cores are compiled instead of a single one
    * Core compilation is parallelized
    * Coverage report merges coverage information of all cores
* Add `--seed-gen-timeout <mins>` option to `fuzzer`  subcommand that interrupt seed generation after `mins` have passed.
* Coverage report is now logged under `output/<lib>/coverage_report.txt`