### PR TITLE
Cov time time seeds

### DIFF
--- a/scripts/cntg_coverage-over-time.py
+++ b/scripts/cntg_coverage-over-time.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Generates a coverage-over-time graph based on seed metadata (seed_meta.csv).
+
+Example CSV headers (see output/zlib/seed_meta.csv):
+    seed_path,duration_since_start,cumulative_branch_coverage
+
+Usage:
+    python scripts/cntg_coverage-over-time.py output/<lib>/seed_meta.csv \
+        -o output/<lib>/coverage_over_time.png
+
+Notes:
+    - Expects at least two columns: time (default: duration_since_start) and
+      coverage (default: cumulative_branch_coverage).
+    - Time is plotted in minutes by default; use --time-unit seconds to keep seconds.
+    - Saves a PNG if -o/--output is provided; otherwise shows an interactive window.
+"""
+
+import argparse
+import csv
+from pathlib import Path
+from typing import List, Tuple
+
+import matplotlib.pyplot as plt
+
+
+def read_series(
+    csv_path: Path,
+    time_col: str,
+    cov_col: str,
+) -> Tuple[List[float], List[float]]:
+    xs: List[float] = []
+    ys: List[float] = []
+    with csv_path.open("r", newline="") as f:
+        reader = csv.DictReader(f)
+        # Validate required columns early
+        if time_col not in reader.fieldnames or cov_col not in reader.fieldnames:
+            raise SystemExit(
+                f"CSV missing required columns: '{time_col}' and/or '{cov_col}'.\n"
+                f"Found columns: {reader.fieldnames}"
+            )
+        for row in reader:
+            try:
+                t = float(row[time_col])
+                c = float(row[cov_col])
+            except (TypeError, ValueError) as e:
+                # Skip malformed rows but keep going
+                continue
+            xs.append(t)
+            ys.append(c)
+    if not xs:
+        raise SystemExit("No valid data rows parsed from CSV.")
+    return xs, ys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot coverage over time from CNTG seed metadata (CSV)."
+    )
+    parser.add_argument(
+        "csv",
+        type=Path,
+        help="Path to seed_meta.csv (e.g., output/<lib>/seed_meta.csv)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Output PNG path. If omitted, displays the figure interactively.",
+    )
+    parser.add_argument(
+        "--time-col",
+        default="duration_since_start",
+        help="CSV column for time values (default: duration_since_start)",
+    )
+    parser.add_argument(
+        "--cov-col",
+        default="cumulative_branch_coverage",
+        help="CSV column for coverage values (default: cumulative_branch_coverage)",
+    )
+    parser.add_argument(
+        "--title",
+        default=None,
+        help="Plot title (default: inferred from CSV path)",
+    )
+    parser.add_argument(
+        "--time-unit",
+        choices=["seconds", "minutes"],
+        default="minutes",
+        help="Unit for X axis (default: minutes)",
+    )
+    parser.add_argument(
+        "--line-label",
+        default=None,
+        help="Legend label for the line (default: library name inferred from path)",
+    )
+
+    args = parser.parse_args()
+
+    if not args.csv.exists():
+        raise SystemExit(f"CSV not found: {args.csv}")
+
+    xs, ys = read_series(args.csv, args.time_col, args.cov_col)
+
+    # Convert time if needed
+    if args.time_unit == "minutes":
+        xs = [x / 60.0 for x in xs]
+        x_label = "Time (minutes)"
+    else:
+        x_label = "Time (seconds)"
+
+    # Infer a name from the path if not provided
+    inferred_name = args.csv.parent.name  # typically the <lib> folder under output/
+    line_label = args.line_label or inferred_name
+
+    # Title
+    default_title = f"Coverage Over Time ({inferred_name})"
+    title = args.title or default_title
+
+    plt.figure(figsize=(8, 4.5))
+    plt.plot(xs, ys, label=line_label, color="#1f77b4", linewidth=2.0)
+    plt.xlabel(x_label)
+    plt.ylabel("Cumulative Branch Coverage (%)")
+    plt.title(title)
+    plt.grid(True, linestyle=":", alpha=0.6)
+    plt.tight_layout()
+    if line_label:
+        plt.legend()
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(args.output, dpi=200)
+        print(f"Saved figure to: {args.output}")
+    else:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib==3.10.7

--- a/src/cntg_program/mod.rs
+++ b/src/cntg_program/mod.rs
@@ -67,7 +67,7 @@ impl CNTGProgram {
     ///
     /// Each program contains `self.batch` number of seeds and a large core that calls functions in each seed sequentially.
     pub fn synthesis(&mut self, outdir: &Path) -> Result<()> {
-        log::info!("synthesis huge CNTG cores!");
+        log::debug!("synthesis huge CNTG cores!");
 
         let mut batch = Vec::new();
         let mut batch_id = Vec::new();
@@ -185,7 +185,7 @@ impl CNTGProgram {
                     s.spawn(|| {
                         let core_dir = dir.unwrap().path();
                         if core_dir.is_dir() {
-                            log::info!("Compile to Core: {core_dir:?}");
+                            log::debug!("Compile to Core: {core_dir:?}");
                             let core_binary = get_core_path(&core_dir);
                             executor.compile_lib_fuzzers(
                                 &core_dir,

--- a/src/cntg_program/mod.rs
+++ b/src/cntg_program/mod.rs
@@ -12,6 +12,7 @@ use eyre::{Context, Result, eyre};
 
 /// CNTGProgram represents a single executable created from multiple API combination programs.
 /// Unlike LibFuzzer, this keeps the original main() functions and fuses them into one binary.
+#[derive(Clone)]
 pub struct CNTGProgram {
     /// programs to fuse into a single executable
     programs: Vec<PathBuf>,

--- a/src/cntg_program/seed_metas.rs
+++ b/src/cntg_program/seed_metas.rs
@@ -122,7 +122,6 @@ impl SeedMetas {
             program.compile(&seed_dir)?;
 
             // Execute program
-            executor.collect_cntg_cov_all_cores(&seed_dir)?;
             let (tx, rx) = std::sync::mpsc::channel();
             let handle = std::thread::spawn({
                 let local_executor = executor.clone();
@@ -132,7 +131,7 @@ impl SeedMetas {
                     tx.send(result).unwrap();
                 }
             });
-            match rx.recv_timeout(Duration::from_secs(60)) {
+            match rx.recv_timeout(Duration::from_secs(30)) {
                 Ok(Err(err)) => {
                     log::warn!("Failed to collect coverage for batch {batch_id}");
                     continue;

--- a/src/cntg_program/seed_metas.rs
+++ b/src/cntg_program/seed_metas.rs
@@ -86,7 +86,11 @@ impl SeedMetas {
         Ok(())
     }
 
-    pub fn update_cov(&mut self, deopt: &Deopt) -> Result<()> {
+    /// Update the cumulative_coverage of seeds
+    ///
+    /// Coverage computation can be batched for speed up. `batch_size` seeds
+    /// will be fused together, and their coverage will be computed together.
+    pub fn update_cov(&mut self, deopt: &Deopt, batch_size: usize) -> Result<()> {
         // Ensure seed metas are processed in chronological order
         self.seed_metas
             .sort_by_key(|m| m.duration_since_start);
@@ -96,27 +100,30 @@ impl SeedMetas {
         fs::remove_dir_all(&workspace_dir)?;
         let mut cumulative_profile_exists = false;
         let cumulative_profile_path = workspace_dir.join("cumulative_profile.profdata");
-        for seed_meta in &mut self.seed_metas {
-            let seed_path = seed_meta.seed_path.clone();
-            let mut program = CNTGProgram::new(vec![seed_path.clone()], 1, deopt);
-            let stem = seed_path.file_stem().ok_or_else(|| eyre!("Invalid seed path"))?;
-            let seed_dir = workspace_dir.join(stem);
+        for (batch_id, seed_meta_batch) in &mut self.seed_metas.chunks_mut(batch_size).enumerate() {
+            // Set up coverage environment
+            let seed_paths: Vec<_> = seed_meta_batch.iter().map(|seed_meta| seed_meta.seed_path.clone()).collect();
+            let mut program = CNTGProgram::new(seed_paths.clone(), 1, deopt);
+            let stems: Vec<_> = seed_paths.iter().map(|seed_path| seed_path.file_stem()).collect();
+            let lower_stem = seed_paths.first().unwrap().file_stem().unwrap().to_str().unwrap_or("unknown");
+            let higher_stem = seed_paths.last().unwrap().file_stem().unwrap().to_str().unwrap_or("unknown");
+            let seed_dir = workspace_dir.join(batch_id.to_string() + "_" + lower_stem + "_" + &higher_stem);
             match fs::remove_dir_all(&seed_dir) {
                 Ok(_) => (),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => (),
                 Err(e) => return Err(eyre!(e)),
             }
             fs::create_dir_all(&seed_dir)?;
+
+            // Create coverage information
+            let executor = Executor::new(&deopt)?;
             program.chdir(&seed_dir)?;
             program.synthesis(&seed_dir)?;
             program.compile(&seed_dir)?;
-
-            let executor = Executor::new(&deopt)?;
             executor.collect_cntg_cov_all_cores(&seed_dir)?;
-            let seed_profdata_path: PathBuf = seed_dir.join("default.profdata");
-            if !cumulative_profile_exists {
-            }
 
+            // Parse and record
+            let seed_profdata_path: PathBuf = seed_dir.join("default.profdata");
             let coverage: CodeCoverage;
             if cumulative_profile_exists {
                 Executor::merge_profdata(&vec![cumulative_profile_path.clone(), seed_profdata_path.clone()], &cumulative_profile_path)?;
@@ -127,10 +134,9 @@ impl SeedMetas {
                 cumulative_profile_exists = true;
             }
             let coverage_summary = coverage.get_total_summary();
-            seed_meta.cumulative_branch_coverage = Some(coverage_summary.get_percent_branch_covered());
+            seed_meta_batch.iter_mut().for_each(|seed_meta| seed_meta.cumulative_branch_coverage = Some(coverage_summary.get_percent_branch_covered()));
 
-            let seed_path_str = seed_path.to_str().unwrap_or("unknown");
-            log::debug!("Cumulative coverage for {} is {}", seed_path_str, &seed_meta.cumulative_branch_coverage.unwrap());
+            log::debug!("Cumulative coverage from seed {} to {} is {}", &lower_stem, &higher_stem, &coverage_summary.get_percent_branch_covered());
         }
         Ok(())
     }

--- a/src/cntg_program/seed_metas.rs
+++ b/src/cntg_program/seed_metas.rs
@@ -103,7 +103,7 @@ impl SeedMetas {
         for (batch_id, seed_meta_batch) in &mut self.seed_metas.chunks_mut(batch_size).enumerate() {
             // Set up coverage environment
             let seed_paths: Vec<_> = seed_meta_batch.iter().map(|seed_meta| seed_meta.seed_path.clone()).collect();
-            let mut program = CNTGProgram::new(seed_paths.clone(), 1, deopt);
+            let mut program = CNTGProgram::new(seed_paths.clone(), batch_size, deopt);
             let stems: Vec<_> = seed_paths.iter().map(|seed_path| seed_path.file_stem()).collect();
             let lower_stem = seed_paths.first().unwrap().file_stem().unwrap().to_str().unwrap_or("unknown");
             let higher_stem = seed_paths.last().unwrap().file_stem().unwrap().to_str().unwrap_or("unknown");
@@ -126,6 +126,7 @@ impl SeedMetas {
             let seed_profdata_path: PathBuf = seed_dir.join("default.profdata");
             let coverage: CodeCoverage;
             if cumulative_profile_exists {
+                log::debug!("Merging profile data...");
                 Executor::merge_profdata(&vec![cumulative_profile_path.clone(), seed_profdata_path.clone()], &cumulative_profile_path)?;
                 coverage = executor.obtain_cov_summary_from_profdata(&cumulative_profile_path)?;
             } else {


### PR DESCRIPTION
### Summary

Fix bugs in coverage collection, improve compilation, and create graph

### Description

* New `scripts` directory for holding python scripts used for data analysis
  * New script scripts/cntg_coverage-over-time.py for generating coverage-over-time graph. See help message.
* Add timeout in seed execution for coverage collection.
  * Originally, some seeds will hang, causing the entire coverage collection to hang. Now, these seeds are ignored.
* Merge compilation pipeline
  * Originally, compilation for Api sequence generation uses hard-coded command.
  * Originally, uses externally installed libraries
  * Now, uses built-in compilation pipeline (i.e. `self.compile`)
  * Now, uses library built by `data/<lib>/build.sh` (specifically the coverage-no-fuzz target, as all the other targets compile for fuzzers instead of normal programs)